### PR TITLE
use backtrace_exclusion_patterns instead backtrace_clean

### DIFF
--- a/lib/rspec_api_documentation/dsl.rb
+++ b/lib/rspec_api_documentation/dsl.rb
@@ -14,4 +14,4 @@ end
 RSpec.configuration.include RspecApiDocumentation::DSL::Resource, :api_doc_dsl => :resource
 RSpec.configuration.include RspecApiDocumentation::DSL::Endpoint, :api_doc_dsl => :endpoint
 RSpec.configuration.include RspecApiDocumentation::DSL::Callback, :api_doc_dsl => :callback
-RSpec.configuration.backtrace_clean_patterns << %r{lib/rspec_api_documentation/dsl\.rb}
+RSpec.configuration.backtrace_exclusion_patterns << %r{lib/rspec_api_documentation/dsl/}


### PR DESCRIPTION
We can avoid some deprecations warnings with this where this fork is used.
